### PR TITLE
vars: updating the aws_ami description

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ module "dcos-private-agent-instances" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs | string | `` | no |
+| aws_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ | string | `` | no |
 | aws_associate_public_ip_address | Associate a public IP address with the instances | string | `true` | no |
 | aws_iam_instance_profile | Instance profile to be used for these instances | string | `` | no |
 | aws_instance_type | Instance type | string | `t2.medium` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "tags" {
 }
 
 variable "aws_ami" {
-  description = "AMI that will be used for the instances instead of Mesosphere provided AMIs"
+  description = "AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/"
   default     = ""
 }
 


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-47942

This commit is to be more descriptive on the aws_ami variable to allow users more visibility into what AMI's are required and how they are built.
The link to the mesosphere documentation is in the description of the variable.